### PR TITLE
Make team memberships public

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,7 +19,9 @@ This governance model is designed to uphold the principles of transparency, open
 
 ## Roles and Responsibilities
 
-- **Code owners:** Individuals with write access to any repository within the GitHub organisation, responsible for reviewing and merging contributions, and steering project direction. These individuals (or groups) will be maintained in each repository (`.github/CODEOWNERS`).
+- **Code owners:** Individuals with write access to any repository within the GitHub organisation, responsible for reviewing and merging contributions, and steering project direction. 
+  Those people with code ownership responsibilities will be identified in each repository (`.github/CODEOWNERS`).
+  For the sake of transparency, the membership of github teams will be made public in [TEAMS.md](TEAMS.md).
 - **Contributors:** Anyone who contributes to the project in any form.
 
 Reference: [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

--- a/TEAMS.md
+++ b/TEAMS.md
@@ -1,0 +1,37 @@
+
+# People
+
+The following people are members of at least one team.
+The format is: `{preferred name}, {affiliation} (@{github_username})`
+
+* Tom Bentley, IBM (@tombentley)
+* Robert Young, IBM (@robobario)
+* Sam Barker, IBM (@SamBarker)
+* Grace Grimwood, IBM (@gracegrimwood)
+* Keith Wall, IBM (@k-wall)
+* Francisco Vila, IBM (@franvila)
+
+# Teams
+
+The following sections publicise the membership of the organization's teams.
+The format for each item is `@{github_username}`, which can be cross-referenced with the people above.
+
+# `@kroxylicious/admins`
+
+* @tombentley
+* @robobario
+* @SamBarker
+* @gracegrimwood
+* @k-wall
+* @franvila
+
+## `@kroxylicious/developers`
+
+* @tombentley
+* @robobario
+* @SamBarker
+* @gracegrimwood
+* @k-wall
+* @franvila
+
+


### PR DESCRIPTION
Transparency on this could be important to someone who was thinking about getting involved with the project.

This is necessary because github does not make team memberships public (there's not even an _option_ for making them public).