### PR TITLE
Contributor: Add guidance about finding an issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ You can contribute by:
 All bugs, tasks or enhancements are tracked as GitHub issues.
 Issues which might be a good start for new contributors are marked with the “good-start” label.
 
+## Finding an Issue
+
+We have issues labelled [good first issue](https://github.com/kroxylicious/kroxylicious/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for new contributors and [help wanted](https://github.com/kroxylicious/kroxylicious/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issues suitable for any contributor. 
+
+Sometimes there won’t be any issues with these labels. That’s ok! There is likely still something for you to work on. If you want to contribute but you
+don’t know where to start or can't find a suitable issue, you can come [chat to us](https://kroxylicious.slack.com/archives/C050RNMQW8G).
+
+Once you see an issue that you'd like to work on, please post a comment saying that you want to work on it. Something like "I want to work on this" is fine.
+If later you need to change your mind, for whatever reason, that's fine too. Just post another message so others know its free.
+
 ## DCO Signoff
 
 The project requires that all commits are signed-off, indicating that _you_ certify the changes with the [Developer


### PR DESCRIPTION
why: We saw a case where two contributors worked the same issue separately.  We'd like to minimise the chance of this happening without adding too much ceremony. 

I took inspiration from CNCF's words. https://raw.githubusercontent.com/cncf/project-template/refs/heads/main/CONTRIBUTING.md