### PR TITLE
Add action to log on items being moved in org Projects

### DIFF
--- a/.github/workflows/slack-on-blocked.yaml
+++ b/.github/workflows/slack-on-blocked.yaml
@@ -1,0 +1,33 @@
+name: Project Item Move Logger
+
+on:
+  project_item:
+    types:
+      - edited
+
+jobs:
+  debug_payload:
+    runs-on: ubuntu-latest
+    permissions:
+      repository-projects: read
+      issues: read
+      pull-requests: read
+      contents: read
+      
+    steps:
+      - name: Dump GitHub Event Payload
+        env:
+          EVENT_CONTEXT: ${{ toJson(github.event) }}
+        run: |
+          echo "--- FULL EVENT PAYLOAD ---"
+          echo "$EVENT_CONTEXT" | jq .
+          
+      - name: Targeted Echo
+        run: |
+          FIELD_NAME="${{ github.event.changes.field_value.field_name }}"
+          
+          if [ "$FIELD_NAME" = "Status" ]; then
+            echo "Action: Column Move Detected"
+          else
+            echo "Action: Other field edit ($FIELD_NAME)"
+          fi


### PR DESCRIPTION
I would like to be able to send a slack message when a card is moved into Blocked. This PR is testing the guidance I got from the internets that we should be able to use automation in the organization `.github` repo to react to events in the org-level Project. A bit hard to prove in a fork without an org.